### PR TITLE
Add revisionHistoryLimit option to stream-processors chart

### DIFF
--- a/charts/stream-processors/Chart.yaml
+++ b/charts/stream-processors/Chart.yaml
@@ -7,6 +7,6 @@ annotations:
   artifacthub.io/changes: |
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed and security.
-    - kind: changed
-      description: bumped version to test changelog generation
-version: 1.1.4
+    - kind: added
+      description: added configuration options for the deployments revisionHistoryLimit
+version: 1.1.5

--- a/charts/stream-processors/README.md
+++ b/charts/stream-processors/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the `stream-processors`
 | securityContext.runAsUser                |                                                                                                                                                                           | `11111`      |
 | securityContext.runAsGroup               |                                                                                                                                                                           | `11111`      |
 | defaultReplicaCount                      | sets the replicas value for all processor deployment unless overriden on a per-processor level as `.replicaCount`                                                         | `1`          |
+| defaultRevisionHistoryLimit              | sets the revisionHistoryLimit value for all processor deployment unless overriden on a per-processor level as `.revisionHistoryLimit`                                     | `10`         |
 | processors                               | list of stream processing deployments. See [values-test.yaml](values-test.yaml) for an example                                                                            | `{}`         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/charts/stream-processors/templates/deployment.yaml
+++ b/charts/stream-processors/templates/deployment.yaml
@@ -16,6 +16,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ default $.Values.defaultReplicaCount .replicaCount }}
+  revisionHistoryLimit: {{ default $.Values.defaultRevisionHistoryLimit .revisionHistoryLimit }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ $name }}

--- a/charts/stream-processors/values-test.yaml
+++ b/charts/stream-processors/values-test.yaml
@@ -1,6 +1,7 @@
 processors:
   nginx:
     replicaCount: 1
+    revisionHistoryLimit: 0
     container:
       image:
         registry: docker.io

--- a/charts/stream-processors/values.yaml
+++ b/charts/stream-processors/values.yaml
@@ -34,5 +34,8 @@ securityContext:
 # sets the replicas value for all processor deployment unless overriden on a per-processor level as `.replicaCount`
 defaultReplicaCount: 1
 
+# sets the revisionHistoryLimit value for all processor deployment unless overriden on a per-processor level as `.revisionHistoryLimit`
+defaultRevisionHistoryLimit: 10
+
 # list of stream processing deployments. See [values-test.yaml](values-test.yaml) for an example
 processors: {}


### PR DESCRIPTION
A lower `Deployment.spec.revisionHistoryLimit` will make Kubernetes [clean up old ReplicaSets](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) earlier.

Especially useful when using GitOps-Tools like ArgoCD, since it makes the AgroProjects much clearer and Kubernetes Deployment rollback features are not needed, anyway.