### PR TITLE
Add configuration options for the deployments tolerations

### DIFF
--- a/charts/stream-processors/Chart.yaml
+++ b/charts/stream-processors/Chart.yaml
@@ -8,5 +8,5 @@ annotations:
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed and security.
     - kind: added
-      description: added configuration options for the deployments revisionHistoryLimit
-version: 1.1.5
+      description: added configuration options for the deployments tolerations
+version: 1.1.6

--- a/charts/stream-processors/README.md
+++ b/charts/stream-processors/README.md
@@ -66,8 +66,9 @@ The following table lists the configurable parameters of the `stream-processors`
 | securityContext.runAsNonRoot             |                                                                                                                                                                           | `true`       |
 | securityContext.runAsUser                |                                                                                                                                                                           | `11111`      |
 | securityContext.runAsGroup               |                                                                                                                                                                           | `11111`      |
-| defaultReplicaCount                      | sets the replicas value for all processor deployment unless overriden on a per-processor level as `.replicaCount`                                                         | `1`          |
-| defaultRevisionHistoryLimit              | sets the revisionHistoryLimit value for all processor deployment unless overriden on a per-processor level as `.revisionHistoryLimit`                                     | `10`         |
+| defaultReplicaCount                      | sets the replicas value for all processor deployments unless overriden on a per-processor level as `.replicaCount`                                                        | `1`          |
+| defaultRevisionHistoryLimit              | sets the revisionHistoryLimit value for all processor deployments unless overriden on a per-processor level as `.revisionHistoryLimit`                                    | `10`         |
+| defaultTolerations                       | sets list of tolerations for all processor deployments unless overriden on a per-processor level as `.tolerations`                                                        | `[]`         |
 | processors                               | list of stream processing deployments. See [values-test.yaml](values-test.yaml) for an example                                                                            | `{}`         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/charts/stream-processors/templates/deployment.yaml
+++ b/charts/stream-processors/templates/deployment.yaml
@@ -99,8 +99,10 @@ spec:
               mountPath: "/opt/kafka-certs"
               readOnly: true
         {{- if .extraContainers }}
-        {{- toYaml .extraContainers | nindent 8}}
+        {{- toYaml .extraContainers | nindent 8 }}
         {{- end }}
+      tolerations:
+        {{- .tolerations | default $.Values.defaultTolerations | toYaml | nindent 8 }}
       volumes:
         - name: kafka-certs
           projected:

--- a/charts/stream-processors/values-test.yaml
+++ b/charts/stream-processors/values-test.yaml
@@ -52,6 +52,10 @@ processors:
           runAsUser: 11111
           runAsGroup: 11111
           readOnlyRootFilesystem: true
+    tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
   ahd2fhir:
     metrics:
       enabled: true

--- a/charts/stream-processors/values.yaml
+++ b/charts/stream-processors/values.yaml
@@ -31,11 +31,14 @@ securityContext:
   runAsUser: 11111
   runAsGroup: 11111
 
-# sets the replicas value for all processor deployment unless overriden on a per-processor level as `.replicaCount`
+# sets the replicas value for all processor deployments unless overriden on a per-processor level as `.replicaCount`
 defaultReplicaCount: 1
 
-# sets the revisionHistoryLimit value for all processor deployment unless overriden on a per-processor level as `.revisionHistoryLimit`
+# sets the revisionHistoryLimit value for all processor deployments unless overriden on a per-processor level as `.revisionHistoryLimit`
 defaultRevisionHistoryLimit: 10
+
+# sets list of tolerations for all processor deployments unless overriden on a per-processor level as `.tolerations`
+defaultTolerations: []
 
 # list of stream processing deployments. See [values-test.yaml](values-test.yaml) for an example
 processors: {}


### PR DESCRIPTION
Enables configuring pod tolerations on a per-deployment level, or globally, just like replicaCounts etc.