### PR TITLE
Re-enable CI documentation check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      #- name: Check if documentation is up-to-date
-      #  run: generate-docs.sh && git diff --exit-code HEAD
+      - name: Check if documentation is up-to-date
+        run: generate-docs.sh && git diff --exit-code HEAD
       - name: Update dependencies
         run: find charts/ ! -path charts/ -maxdepth 1 -type d -exec helm dependency update {} \;
       - name: Run YAML lint


### PR DESCRIPTION
In #71 I disabled the documentation check because it was failing all the time due to `generate-docs.sh` introducing HTML tags into the readme, where they don't belong. I could not reproduce this behaviour locally, so my only temporary quick-fix was to disable the check completely.

Since I maybe was running a cached `latest` version of the pwoertools container image – has something changed here recently @chgl ?