### PR TITLE
updated fhir gw docs to no longer include chart version

### DIFF
--- a/charts/fhir-gateway/Chart.yaml
+++ b/charts/fhir-gateway/Chart.yaml
@@ -10,10 +10,10 @@ dependencies:
     version: 10.12.7
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
-version: 3.6.0
+version: 3.6.1
 annotations:
   artifacthub.io/changes: |
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed and security.
     - kind: changed
-      description: use archived bitnami charts index for postgresql dependency. See <https://github.com/bitnami/charts/issues/10833>.
+      description: updated README template to no longer include the chart version

--- a/charts/fhir-gateway/README.md
+++ b/charts/fhir-gateway/README.md
@@ -7,7 +7,7 @@
 ```console
 $ helm repo add miracum https://miracum.github.io/charts
 $ helm repo update
-$ helm install fhir-gateway miracum/fhir-gateway -n fhir-gateway --version=3.5.9
+$ helm install fhir-gateway miracum/fhir-gateway -n fhir-gateway
 ```
 
 ## Breaking changes
@@ -31,7 +31,7 @@ This chart deploys the MIRACUM FHIR Gateway on a [Kubernetes](http://kubernetes.
 To install the chart with the release name `fhir-gateway`:
 
 ```console
-$ helm install fhir-gateway miracum/fhir-gateway -n fhir-gateway --version=3.5.9
+$ helm install fhir-gateway miracum/fhir-gateway -n fhir-gateway
 ```
 
 The command deploys the MIRACUM FHIR Gateway on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -136,14 +136,14 @@ The following table lists the configurable parameters of the `fhir-gateway` char
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install fhir-gateway miracum/fhir-gateway -n fhir-gateway --version=3.5.9 --set replicaCount=1
+$ helm install fhir-gateway miracum/fhir-gateway -n fhir-gateway --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install fhir-gateway miracum/fhir-gateway -n fhir-gateway --version=3.5.9 --values values.yaml
+$ helm install fhir-gateway miracum/fhir-gateway -n fhir-gateway --values values.yaml
 ```
 
 ## Pseudonymization

--- a/charts/fhir-gateway/README.tpl
+++ b/charts/fhir-gateway/README.tpl
@@ -7,7 +7,7 @@
 ```console
 $ helm repo add {{ .Repository.Name }} {{ .Repository.URL }}
 $ helm repo update
-$ helm install {{ .Release.Name }} {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }}{{ with .Chart.Version }} --version={{.}}{{ end }}
+$ helm install {{ .Release.Name }} {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }}
 ```
 
 ## Breaking changes
@@ -31,7 +31,7 @@ This chart deploys {{ .Project.App }} on a [Kubernetes](http://kubernetes.io) cl
 To install the chart with the release name `{{ .Release.Name }}`:
 
 ```console
-$ helm install {{ .Release.Name }} {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }}{{ with .Chart.Version }} --version={{.}}{{ end }}
+$ helm install {{ .Release.Name }} {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }}
 ```
 
 The command deploys {{ .Project.App }} on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -57,14 +57,14 @@ The following table lists the configurable parameters of the `{{ .Chart.Name }}`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install {{ .Release.Name }} {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }}{{ with .Chart.Version }} --version={{.}}{{ end }} --set {{ .Chart.ValuesExample }}
+$ helm install {{ .Release.Name }} {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }} --set {{ .Chart.ValuesExample }}
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install {{ .Release.Name }} {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }}{{ with .Chart.Version }} --version={{.}}{{ end }} --values values.yaml
+$ helm install {{ .Release.Name }} {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }} --values values.yaml
 ```
 
 ## Pseudonymization


### PR DESCRIPTION
simplifies updates since now not every single change that bumped the
Chart.yaml version requires doc rebuilds.