### PR TITLE
chore(renovate): ignore recruit chart updates

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -31,5 +31,10 @@
       "matchPackageNames": ["postgresql", "ghcr.io/chgl/kube-powertools"],
       "extends": ["schedule:monthly"]
     }
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "charts/recruit/**"
   ]
 }


### PR DESCRIPTION
The helm chart is managed in the upstream recruit repo.